### PR TITLE
Make submenu items non-nullable

### DIFF
--- a/lib/src/menu.dart
+++ b/lib/src/menu.dart
@@ -1,14 +1,14 @@
 import 'menu_item.dart';
 
 class Menu {
-  List<MenuItem>? items;
+  final List<MenuItem> items;
 
-  Menu({
-    this.items,
+  const Menu({
+    this.items = const [],
   });
 
   MenuItem? getMenuItem(String key) {
-    for (MenuItem menuItem in (items ?? [])) {
+    for (MenuItem menuItem in items) {
       if (menuItem.key == key) {
         return menuItem;
       }
@@ -20,7 +20,7 @@ class Menu {
   }
 
   MenuItem? getMenuItemById(int id) {
-    for (MenuItem menuItem in (items ?? [])) {
+    for (MenuItem menuItem in items) {
       if (menuItem.id == id) {
         return menuItem;
       }
@@ -33,7 +33,7 @@ class Menu {
 
   Map<String, dynamic> toJson() {
     return {
-      'items': items?.map((e) => e.toJson()).toList(),
+      'items': items.map((e) => e.toJson()).toList(),
     }..removeWhere((key, value) => value == null);
   }
 }

--- a/lib/src/menu_item.dart
+++ b/lib/src/menu_item.dart
@@ -33,13 +33,12 @@ class MenuItem {
     this.toolTip,
     this.icon,
     this.disabled = false,
-    List<MenuItem>? items = const [],
-    this.submenu = const Menu(items: []),
+    List<MenuItem> items = const [],
+    Menu? submenu,
     this.onClick,
   })  : id = _generateMenuItemId(),
-        type = 'submenu' {
-    submenu!.items.addAll(items!);
-  }
+        type = 'submenu',
+        submenu = (submenu?..items.addAll(items)) ?? Menu(items: items);
 
   MenuItem.checkbox({
     this.key,

--- a/lib/src/menu_item.dart
+++ b/lib/src/menu_item.dart
@@ -33,10 +33,13 @@ class MenuItem {
     this.toolTip,
     this.icon,
     this.disabled = false,
-    this.submenu,
+    List<MenuItem>? items = const [],
+    this.submenu = const Menu(items: []),
     this.onClick,
   })  : id = _generateMenuItemId(),
-        type = 'submenu';
+        type = 'submenu' {
+    submenu!.items.addAll(items!);
+  }
 
   MenuItem.checkbox({
     this.key,

--- a/lib/src/menu_item.dart
+++ b/lib/src/menu_item.dart
@@ -33,12 +33,10 @@ class MenuItem {
     this.toolTip,
     this.icon,
     this.disabled = false,
-    List<MenuItem> items = const [],
-    Menu? submenu,
+    this.submenu = const Menu(),
     this.onClick,
   })  : id = _generateMenuItemId(),
-        type = 'submenu',
-        submenu = (submenu?..items.addAll(items)) ?? Menu(items: items);
+        type = 'submenu';
 
   MenuItem.checkbox({
     this.key,


### PR DESCRIPTION
I'm not 100% certain, but I think the Windows plugin version of [contextual_menu](https://github.com/leanflutter/contextual_menu) can't handle the JSON skipping the `Menu.items` field if it's empty.

This proposal makes the field non-nullable. It also adds an `items` shorthand to the `MenuItem.submenu` constructor. The API stays backwards compatible by introducing default values.