### PR TITLE
Add a shorthand for adding `MenuItems` in the `MenuItem.submenu` constructor

### DIFF
--- a/lib/src/menu_item.dart
+++ b/lib/src/menu_item.dart
@@ -33,10 +33,11 @@ class MenuItem {
     this.toolTip,
     this.icon,
     this.disabled = false,
-    this.submenu,
+    List<MenuItem> entries = const [],
     this.onClick,
   })  : id = _generateMenuItemId(),
-        type = 'submenu';
+        type = 'submenu',
+        submenu = Menu(items: entries);
 
   MenuItem.checkbox({
     this.key,


### PR DESCRIPTION
As proposed in #1 I've split this part of the patch off.

I personally don't have much of a preference on the whole matter, beyond maybe trying to not introduce a breaking change. So this patch is more of a suggestion.